### PR TITLE
Update Services.yml

### DIFF
--- a/src/Configuration/features/RaxOS/Services.yml
+++ b/src/Configuration/features/RaxOS/Services.yml
@@ -84,6 +84,7 @@ actions:
 - !service: {name: 'TrkWks', operation: change, startup: 4}
 - !service: {name: 'WSearch', operation: change, startup: 4}
 - !service: {name: 'DsSvc', operation: change, startup: 4}
+- !service: {name: 'NPSMSvc', operation: change, startup: 4}
 
 - !run: 
   exeDir: true


### PR DESCRIPTION
NPSMSvc Windows service is responsible for showing the now playing media on the volume flyout on Windows 10 and on the action center on Windows 11.
Always running at background, should be safe to disable.